### PR TITLE
Adds the methods toObjectLocalizedOnly and toJSONLocalizedOnly

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function(schema, options) {
 		return localize(obj, locale, false);
 	};
 	
-	var onlyLocalize = function(obj, locale, localeDefault, toJSON) {
+	var localizeOnly = function(obj, locale, localeDefault, toJSON) {
 		var addLocalized = function(obj) {
 			for (var key in obj) {
 				if (key === '_id') continue;
@@ -73,11 +73,11 @@ module.exports = function(schema, options) {
 		else return addLocalized(toJSON ? obj.toJSON() : obj.toObject(), locale);
 	};
 
-	schema.methods.toJSONOnlyLocalized = function(obj, locale, localeDefault) {
-		return onlyLocalize(obj, locale, localeDefault, true);
+	schema.methods.toJSONLocalizedOnly = function(obj, locale, localeDefault) {
+		return localizeOnly(obj, locale, localeDefault, true);
 	};
 
-	schema.methods.toObjectOnlyLocalized = function(obj, locale, localeDefault) {
-		return onlyLocalize(obj, locale, localeDefault, false);
+	schema.methods.toObjectLocalizedOnly = function(obj, locale, localeDefault) {
+		return localizeOnly(obj, locale, localeDefault, false);
 	};
 };

--- a/index.js
+++ b/index.js
@@ -48,4 +48,36 @@ module.exports = function(schema, options) {
 	schema.methods.toObjectLocalized = function(obj, locale) {
 		return localize(obj, locale, false);
 	};
+	
+	var onlyLocalize = function(obj, locale, localeDefault, toJSON) {
+		var addLocalized = function(obj) {
+			for (var key in obj) {
+				if (key === '_id') continue;
+				else if (typeof obj[key] === 'object') {
+					addLocalized(obj[key]);
+					if(obj[key] && obj[key].localized !== undefined) {
+						obj[key] = obj[key].localized;
+					} else if(localeDefault && obj[key] && obj[key].default !== undefined) {
+						obj[key] = obj[key].default;
+					}
+				}
+				else if (key === locale) obj.localized = obj[key];
+				else if (localeDefault && key === localeDefault) obj.default = obj[key];
+			}
+			return obj;
+		};
+
+		if (obj instanceof Array) return obj.map(function(object) {
+			return addLocalized(toJSON ? object.toJSON() : object.toObject(), locale);
+		});
+		else return addLocalized(toJSON ? obj.toJSON() : obj.toObject(), locale);
+	};
+
+	schema.methods.toJSONOnlyLocalized = function(obj, locale, localeDefault) {
+		return onlyLocalize(obj, locale, localeDefault, true);
+	};
+
+	schema.methods.toObjectOnlyLocalized = function(obj, locale, localeDefault) {
+		return onlyLocalize(obj, locale, localeDefault, false);
+	};
 };


### PR DESCRIPTION
Adds the methods toObjectLocalizedOnly(resource, locale, localeDefault) and toJSONLocalizedOnly(resource, locale, localeDefault) to the i18n schema methods.

Starting from:

```
[
    {
        name: {
            en: 'hello',
            de: 'hallo',
            it: 'ciao'
        }
    }
]
```

To get only 'it' locale of a resource, just do:

```
Model.find(function(err, resources) {
    var localizedOnlyResources = Model.schema.methods.toJSONLocalizedOnly(resources, 'it', 'en');
});
```

localizedOnlyResources has now the following structure:

```
[
    {
        name: 'ciao'
    }
]
```

if "it" locale not exists, then returns default language (en)

```
[
    {
        name: 'hello'
    }
]
```
