### PR TITLE
Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules/
 .idea
+
+.vscode

--- a/index.js
+++ b/index.js
@@ -60,12 +60,14 @@ module.exports = function(schema, options) {
 
 	function localyzeCapsule(obj, slug, locale, localeDefault, only) {
 		var val, defVal;
-		locale && (val = obj[slug][locale]);
-		localeDefault && (defVal = obj[slug][localeDefault]);
-		if (only) {
-			obj[slug] = val || defVal;
-		} else {
-			obj[slug].localized = val || defVal;
+		if (obj[slug]) {
+			locale && (val = obj[slug][locale]);
+			localeDefault && (defVal = obj[slug][localeDefault]);
+			if (only) {
+				obj[slug] = val || defVal;
+			} else {
+				obj[slug].localized = val || defVal;
+			}
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -105,8 +105,11 @@ module.exports = function(schema, options) {
 		return _obj;
 	}
 
-	function guessMorphAndApply(_this, args, extra) {
+	function guessMorphAndApply(_this, args, extra, methodNAme) {
 		var newArgs=[], argsNum = 3, target = args[0], ret;
+		if (typeof args[0] !== 'string' || typeof args[1] !== 'string') {
+			throw new Error('mongoose-i18n-localize: '+methodNAme+'(): no locale name argument specified!')
+		}
 		if (typeof args[0] === 'string' && _this.hasOwnProperty('isNew')) {
 			newArgs.push(target = _this);
 			argsNum = 2;
@@ -128,18 +131,18 @@ module.exports = function(schema, options) {
 	}
 
 	schema.methods.toJSONLocalized = function() {
-		return guessMorphAndApply(this, arguments, [true, false]);
+		return guessMorphAndApply(this, arguments, [true, false], 'toJSONLocalized');
 	};
 
 	schema.methods.toObjectLocalized = function() {
-		return guessMorphAndApply(this, arguments, [false, false]);
+		return guessMorphAndApply(this, arguments, [false, false], 'toObjectLocalized');
 	};
 
 	schema.methods.toJSONLocalizedOnly = function() {
-		return guessMorphAndApply(this, arguments, [true, true]);
+		return guessMorphAndApply(this, arguments, [true, true], 'toJSONLocalizedOnly');
 	};
 
 	schema.methods.toObjectLocalizedOnly = function() {
-		return guessMorphAndApply(this, arguments, [false, true]);
+		return guessMorphAndApply(this, arguments, [false, true], 'toObjectLocalizedOnly');
 	};
 };

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports = function(schema, options) {
 		} else if (typeof args[1] === 'string') {
 			localeName = args[1];
 		}
-		if (!localeName || options_locales.indexOf(localeName) === -1) {
+		if (!localeName) {
 			throw new Error('mongoose-i18n-localize: '+methodNAme+'(): no valid locale name argument specified!')
 		}
 		if (localeName && _this.hasOwnProperty('isNew')) {

--- a/index.js
+++ b/index.js
@@ -51,7 +51,6 @@ module.exports = function(schema, options) {
 					var i18nCapsulePath = (prePath+(prePath&&'.')+schemaPath).replace(i18nCapsulePathMask, '$1');
 					if (i18nPathCapsules.indexOf(i18nCapsulePath) === -1) {
 						i18nPathCapsules.push(i18nCapsulePath);
-						break;
 					}
 				}
 			}
@@ -106,11 +105,16 @@ module.exports = function(schema, options) {
 	}
 
 	function guessMorphAndApply(_this, args, extra, methodNAme) {
-		var newArgs=[], argsNum = 3, target = args[0], ret;
-		if (typeof args[0] !== 'string' || typeof args[1] !== 'string') {
-			throw new Error('mongoose-i18n-localize: '+methodNAme+'(): no locale name argument specified!')
+		var newArgs=[], argsNum = 3, target = args[0], ret, localeName;
+		if (typeof args[0] === 'string') {
+			localeName = args[0];
+		} else if (typeof args[1] === 'string') {
+			localeName = args[1];
 		}
-		if (typeof args[0] === 'string' && _this.hasOwnProperty('isNew')) {
+		if (!localeName || options_locales.indexOf(localeName) === -1) {
+			throw new Error('mongoose-i18n-localize: '+methodNAme+'(): no valid locale name argument specified!')
+		}
+		if (localeName && _this.hasOwnProperty('isNew')) {
 			newArgs.push(target = _this);
 			argsNum = 2;
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-i18n-localize",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Mongoose plugin to support i18n and localization",
   "author": {
     "name": "Matthias Fey",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-i18n-localize",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Mongoose plugin to support i18n and localization",
   "author": {
     "name": "Matthias Fey",

--- a/test/index.js
+++ b/test/index.js
@@ -3,10 +3,17 @@
 
 var mongoose = require('mongoose');
 
-mongoose.connect('mongodb://localhost/mongoose-i18n-localize');
-mongoose.connection.on('error', function() {
-	throw new Error('Unable to connect to database.');
-});
+before(function name(done) {
+	mongoose.connect('mongodb://localhost/mongoose-i18n-localize');
+	mongoose.connection.on('error', function() {
+		done(new Error('Unable to connect to database.'));
+	});
+	mongoose.connection.on('connected', function() {
+		this.dropDatabase().then(function () {
+			done();
+		})
+	});
+})
 
 describe('Mongoose I18n Localize', function() {
 	require('./tests/i18n')();


### PR DESCRIPTION
So I had found a bug where Node was throwing "Maximum call stack size exceeded" because i18n was trying to traverse Buffer-type fields (they are of Array type during execution) so I started fixing it and it occurred to me that i18n was basically duck typed. If I have a field that has the same name that one of my locales - the extension would try to translate it. Or if I had a custom json in my document that had the same structure. So I thought I might as well do something with it... in the end I've basically rewritten the whole thing almost completely. 

What I did was:

1. during schema config every locale sub-field gets ``_i18n`` option
2. during toJSON/toObject conversion the schema paths are analyzed and the branches that end with _i18n'ed are selected
3. converted object than traversed along only these paths (as opposed to all before) and the changes are applied.

Also I made some fixes to tests and upped the minor version to 0.2.1

Configuration and usage remain the same, tests are running fine. Still if you choose to accept the pull, it is better if you test it on your projects/test cases before you do it - my projects using mongoose-i18n aren't pushing it to the limit...